### PR TITLE
fix global settings cluttering workspace settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,19 +3,21 @@ import * as vscode from 'vscode';
 const nodeModulesPaths = '**/node_modules'
 
 let config = vscode.workspace.getConfiguration()
-let excluded = config.get('files.exclude', {} as Record<string, boolean>)
+let excluded: Record<string, boolean> | undefined
 
-function removeNodeModulesFolder() {
-	excluded[nodeModulesPaths] = true
-	config.update('files.exclude', excluded)
+async function removeNodeModulesFolder() {
+	await config.update('files.exclude', {
+		...excluded,
+		[nodeModulesPaths]: true
+	}, vscode.ConfigurationTarget.Global)
 }
 
-function addNodeModulesFolder() {
-	excluded[nodeModulesPaths] = false
-	config.update('files.exclude', excluded)
+async function addNodeModulesFolder() {
+	await config.update('files.exclude', excluded, vscode.ConfigurationTarget.Global)
 }
 
 async function collapse() {
+	excluded = config.inspect<Record<string, boolean> | undefined>('files.exclude')?.globalValue;
 	await removeNodeModulesFolder()
 	await addNodeModulesFolder()
 }


### PR DESCRIPTION
Hey, thanks for making this extension, I've been so annoyed by massive node_modules folders so it was nice discovering this :)

I had one issue with it. Because vscode has a default list of ignore files, (such as `**/.git`, `**/.svn`), every time I'd use the command a new .vscode/settings.json would be created and this added:

```
{
    "files.exclude": {
        "**/.git": true,
        "**/.svn": true,
        "**/.hg": true,
        "**/CVS": true,
        "**/.DS_Store": true
    }
}
```

This is because it would fetch the `files.exclude` using `config.get()` which includes all settings (default, global, and workspace).
It would add and then remove node_modules, leaving this default exclude list in the local workspace settings file.

I was thinking about how best to solve this and found `config.inspect`, which gives you all three of the different settings.
Using this and config.update with `ConfigurationTarget.Global`, we can merge node_modules into the global settings, then immediately remove them.

The benefits of this is that:
1. .vscode/settings.json if exists is not edited
2. .vscode/settings.json if it doesn't exist is not created

Hope this makes sense! Thanks again.